### PR TITLE
Ignore README.md updates from running travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ env:
   - TEST_COMMAND='test'
   - TEST_COMMAND='lint'
   - TEST_COMMAND='test:integration'
+ignore:
+  - README.md


### PR DESCRIPTION
You can extend this to handle any other files you'd like as well